### PR TITLE
fix: pages with version-1 line blocks silently dropped during sync

### DIFF
--- a/src/app/services/parser/rm-file-parser.spec.ts
+++ b/src/app/services/parser/rm-file-parser.spec.ts
@@ -62,6 +62,7 @@ function buildLineItemData(opts: {
     }>
     deleted?: boolean
     sceneType?: number
+    pointVersion?: 1 | 2
 }): Uint8Array {
     const {
         toolId = PenType.FinelinerV2,
@@ -69,21 +70,39 @@ function buildLineItemData(opts: {
         thickness = 2.0,
         points = [],
         deleted = false,
-        sceneType = SceneItemType.Line
+        sceneType = SceneItemType.Line,
+        pointVersion = 2
     } = opts
 
-    // Build points data (14 bytes per point)
-    const pointsData = new Uint8Array(points.length * 14)
-    const pointsDv = new DataView(pointsData.buffer)
-    for (let i = 0; i < points.length; i++) {
-        const p = points[i]!
-        const off = i * 14
-        pointsDv.setFloat32(off, p.x, true)
-        pointsDv.setFloat32(off + 4, p.y, true)
-        pointsDv.setUint16(off + 8, Math.round((p.speed ?? 1.0) * 4), true)
-        pointsDv.setUint16(off + 10, Math.round((p.width ?? 2.0) * 4), true)
-        pointsData[off + 12] = Math.round(((p.direction ?? 0) * 255) / (Math.PI * 2))
-        pointsData[off + 13] = Math.round((p.pressure ?? 1.0) * 255)
+    let pointsData: Uint8Array
+    if (pointVersion === 1) {
+        // v1: 24 bytes per point, six float32s in natural units
+        pointsData = new Uint8Array(points.length * 24)
+        const pointsDv = new DataView(pointsData.buffer)
+        for (let i = 0; i < points.length; i++) {
+            const p = points[i]!
+            const off = i * 24
+            pointsDv.setFloat32(off, p.x, true)
+            pointsDv.setFloat32(off + 4, p.y, true)
+            pointsDv.setFloat32(off + 8, p.speed ?? 1.0, true)
+            pointsDv.setFloat32(off + 12, p.direction ?? 0, true)
+            pointsDv.setFloat32(off + 16, p.width ?? 2.0, true)
+            pointsDv.setFloat32(off + 20, p.pressure ?? 1.0, true)
+        }
+    } else {
+        // v2: 14 bytes per point, packed integers
+        pointsData = new Uint8Array(points.length * 14)
+        const pointsDv = new DataView(pointsData.buffer)
+        for (let i = 0; i < points.length; i++) {
+            const p = points[i]!
+            const off = i * 14
+            pointsDv.setFloat32(off, p.x, true)
+            pointsDv.setFloat32(off + 4, p.y, true)
+            pointsDv.setUint16(off + 8, Math.round((p.speed ?? 1.0) * 4), true)
+            pointsDv.setUint16(off + 10, Math.round((p.width ?? 2.0) * 4), true)
+            pointsData[off + 12] = Math.round(((p.direction ?? 0) * 255) / (Math.PI * 2))
+            pointsData[off + 13] = Math.round((p.pressure ?? 1.0) * 255)
+        }
     }
 
     // Build value subblock content (scene type + tagged fields + points subblock)
@@ -366,6 +385,80 @@ describe('rm-file-parser', () => {
             expect(stroke.penType).toBe(PenType.CalligraphyPen)
             expect(stroke.color).toBe(StrokeColor.Red)
             expect(stroke.thickness).toBe(3.5)
+        })
+    })
+
+    describe('version 1 blocks (24-byte float points)', () => {
+        test('parses v1 points from a version-1 SceneLineItemBlock', () => {
+            const lineData = buildLineItemData({
+                toolId: PenType.FinelinerV2,
+                colorId: StrokeColor.Black,
+                thickness: 2.0,
+                pointVersion: 1,
+                points: [
+                    { x: 100.5, y: 200.75, speed: 3.5, direction: Math.PI / 2, width: 2.25, pressure: 0.8 },
+                    { x: 150, y: 250 }
+                ]
+            })
+
+            const buffer = new RmFileBuilder()
+                .writeHeader()
+                .writeBlock(BlockType.SceneLineItemBlock, lineData, 1, 1)
+                .build()
+
+            const page = parseRmFile(buffer, 'test', 0)
+            expect(page.strokes).toHaveLength(1)
+
+            const stroke = page.strokes[0]!
+            expect(stroke.points).toHaveLength(2)
+            expect(stroke.points[0]!.x).toBeCloseTo(100.5, 2)
+            expect(stroke.points[0]!.y).toBeCloseTo(200.75, 2)
+            expect(stroke.points[0]!.speed).toBeCloseTo(3.5, 2)
+            expect(stroke.points[0]!.direction).toBeCloseTo(Math.PI / 2, 3)
+            expect(stroke.points[0]!.width).toBeCloseTo(2.25, 2)
+            expect(stroke.points[0]!.pressure).toBeCloseTo(0.8, 2)
+            expect(stroke.points[1]!.x).toBeCloseTo(150, 1)
+            expect(stroke.points[1]!.y).toBeCloseTo(250, 1)
+        })
+
+        test('v1 points parsed as v2 would produce garbage — regression guard', () => {
+            // A v1 block misread with the 14-byte stride yields coordinates far outside
+            // the page (this is the bug: bounds near FLT_MAX crash OffscreenCanvas).
+            // With the fix, coordinates stay within the drawn range.
+            const points = Array.from({ length: 10 }, (_, i) => ({
+                x: 100 + i * 10,
+                y: 200 + i * 5
+            }))
+            const lineData = buildLineItemData({ pointVersion: 1, points })
+
+            const buffer = new RmFileBuilder()
+                .writeHeader()
+                .writeBlock(BlockType.SceneLineItemBlock, lineData, 1, 1)
+                .build()
+
+            const page = parseRmFile(buffer, 'test', 0)
+            expect(page.strokes).toHaveLength(1)
+            for (const p of page.strokes[0]!.points) {
+                expect(Math.abs(p.x)).toBeLessThan(2000)
+                expect(Math.abs(p.y)).toBeLessThan(2000)
+            }
+        })
+
+        test('version 2 blocks still parse with the packed 14-byte format', () => {
+            const lineData = buildLineItemData({
+                pointVersion: 2,
+                points: [{ x: 42, y: 84 }]
+            })
+
+            const buffer = new RmFileBuilder()
+                .writeHeader()
+                .writeBlock(BlockType.SceneLineItemBlock, lineData, 0, 2)
+                .build()
+
+            const page = parseRmFile(buffer, 'test', 0)
+            expect(page.strokes).toHaveLength(1)
+            expect(page.strokes[0]!.points[0]!.x).toBeCloseTo(42, 1)
+            expect(page.strokes[0]!.points[0]!.y).toBeCloseTo(84, 1)
         })
     })
 

--- a/src/app/services/parser/rm-file-parser.ts
+++ b/src/app/services/parser/rm-file-parser.ts
@@ -119,7 +119,7 @@ function skipTagValue(reader: BinaryReader, tagType: TagType): number {
  */
 function parseSceneLineItemBlock(
     reader: BinaryReader,
-    _version: number,
+    version: number,
     blockEnd: number
 ): Stroke | null {
     // Read CRDT item tags until we find the value subblock (tag index 6, Length4)
@@ -130,7 +130,7 @@ function parseSceneLineItemBlock(
             // Value subblock found
             const subLen = reader.readUint32()
             const subEnd = reader.position + subLen
-            const stroke = parseLineValue(reader, subEnd)
+            const stroke = parseLineValue(reader, subEnd, version)
             reader.seek(subEnd)
             return stroke
         }
@@ -154,7 +154,7 @@ function parseSceneLineItemBlock(
 /**
  * Parse the line value inside a CRDT item subblock
  */
-function parseLineValue(reader: BinaryReader, subEnd: number): Stroke | null {
+function parseLineValue(reader: BinaryReader, subEnd: number, version: number): Stroke | null {
     // Scene item type byte (3 = Line)
     const sceneType: SceneItemType = reader.readUint8()
     if (sceneType !== SceneItemType.Line) {
@@ -202,7 +202,10 @@ function parseLineValue(reader: BinaryReader, subEnd: number): Stroke | null {
             case 5: // points subblock (Length4)
                 if (tag.type === TagType.Length4) {
                     const pointsLen = reader.readUint32()
-                    points = parsePointsV2(reader, pointsLen)
+                    points =
+                        version === 1
+                            ? parsePointsV1(reader, pointsLen)
+                            : parsePointsV2(reader, pointsLen)
                 } else {
                     skipTagValue(reader, tag.type)
                 }
@@ -224,6 +227,38 @@ function parseLineValue(reader: BinaryReader, subEnd: number): Stroke | null {
         thickness,
         points
     }
+}
+
+/**
+ * Parse v1 point data: 24 bytes per point (version 1 SceneLineItemBlocks,
+ * written by older reMarkable firmware)
+ * float32 x, float32 y, float32 speed, float32 direction, float32 width, float32 pressure
+ * Values are already in natural units (direction in radians, pressure 0..1),
+ * unlike v2 where they are packed integers that need scaling.
+ */
+function parsePointsV1(reader: BinaryReader, totalBytes: number): StrokePoint[] {
+    const bytesPerPoint = 24
+    const numPoints = Math.floor(totalBytes / bytesPerPoint)
+    const points: StrokePoint[] = []
+
+    for (let i = 0; i < numPoints; i++) {
+        const x = reader.readFloat32()
+        const y = reader.readFloat32()
+        const speed = reader.readFloat32()
+        const direction = reader.readFloat32()
+        const width = reader.readFloat32()
+        const pressure = reader.readFloat32()
+
+        points.push({ x, y, speed, width, direction, pressure })
+    }
+
+    // Skip any remaining bytes (e.g., if totalBytes isn't a perfect multiple)
+    const consumed = numPoints * bytesPerPoint
+    if (consumed < totalBytes) {
+        reader.skip(totalBytes - consumed)
+    }
+
+    return points
 }
 
 /**


### PR DESCRIPTION
## Problem

Some notebook pages silently fail to sync: the progress UI counts them, but no image is written to the vault. There is no visible error — the render exception is caught and converted to `null`.

This affects pages written by older reMarkable firmware (in my case, notebooks from 2022). Several of my notebooks were missing 40–80% of their pages.

## Root cause

`parseBlock` reads the SceneLineItemBlock version from the block header and passes it to `parseSceneLineItemBlock` — where the parameter is named `_version` and never used. All point data is then parsed by `parsePointsV2`, which assumes the version-2 packed 14-byte layout:

```
float32 x, float32 y, uint16 speed, uint16 width, uint8 direction, uint8 pressure
```

But version-1 line blocks store 24-byte points — six float32s (`x, y, speed, direction, width, pressure`), as implemented in the [rmscene](https://github.com/ricklupton/rmscene) reference parser.

Reading 24-byte records at a 14-byte stride shears every subsequent read across field boundaries. Diagnosing with instrumentation, the parsed coordinates come out near ±3.4e38 (FLT_MAX-level garbage), so the stroke bounds computed in `stroke-bounds.ts` explode and `new OffscreenCanvas(w, h)` throws:

```
TypeError: Failed to construct 'OffscreenCanvas': Value is outside the 'unsigned long' value range.
```

`renderPage`'s catch swallows this and returns `null`, and the page is skipped without any user-visible indication.

## Fix

- Thread the block version from `parseSceneLineItemBlock` down to point parsing
- Add `parsePointsV1` for the 24-byte all-float32 layout; values are already in natural units (direction in radians, pressure 0..1), so no scaling is applied — mirroring rmscene's handling
- Version 2 parsing unchanged

## Verification

- Verified against a real notebook that previously lost 4 of 9 pages: after the fix all pages sync and the rendered PNGs match the handwriting shown in the official reMarkable app
- Added specs: v1 point parsing (values + natural units), a regression guard asserting coordinates stay in page range, and a v2 still-works check
- `bun run tsc`, `bun run lint` (0 warnings), `bun test` — 151 pass

## Suggestion (out of scope here)

Even with this fix, a render failure of any future cause is still silent — `renderPage` catches, logs, and drops the page while the panel reports success. A per-page warning in the UI ("N pages failed to render") would make this class of bug user-detectable. Happy to open a separate issue/PR for that if you agree.

https://claude.ai/code/session_0156ELn4A9s2PPYX8DzCf81x