### PR TITLE
feat(panel): sort notebooks within each folder

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,21 @@ All settings are accessible via **Settings → Community plugins → Remarkable 
 
 The quality slider controls the compression level for JPEG and WebP. Lower values produce smaller files; higher values preserve more detail. The slider is hidden when PNG is selected since PNG is always lossless.
 
+## Sorting the panel
+
+The panel's **Sort** picker controls the order of notebooks within each folder:
+
+| Option            | Order                  |
+| ----------------- | ---------------------- |
+| Recently modified | newest first (default) |
+| Oldest modified   | oldest first           |
+| Name (A–Z)        | alphabetical           |
+| Name (Z–A)        | reverse alphabetical   |
+
+Names compare numerically, so "Notebook 2" comes before "Notebook 10" rather than after it. Your choice is remembered between sessions.
+
+Folder order is unaffected: the top-level group stays first, and the rest stay alphabetical.
+
 ## Automatic sync
 
 When **Automatic sync** is enabled, the plugin periodically syncs all notebooks that need updating (same rules as the panel's **Sync all** button). Runs are skipped while disconnected and when a sync is already in progress. Each run also cleans up sync state for notebooks that were deleted on your reMarkable — files already saved in your vault are never deleted.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -57,6 +57,7 @@ The panel shows all your reMarkable notebooks grouped by folder. A connection st
 
 - **Search** — a fuzzy search box filters notebooks by name and folder path
 - **Filter buttons** — toggle between **All**, **Selected**, and **Unselected** to narrow the list
+- **Sort** — order notebooks within each folder by modified date or name, in either direction. The choice is remembered
 
 ### Notebook list
 

--- a/documentation/Business Rules.md
+++ b/documentation/Business Rules.md
@@ -56,6 +56,13 @@ When a new business rule is mentioned:
 - Content pages that fail to render are never dropped silently: the pipeline counts them, the panel shows "Done — N pages failed to render" (warning color), and the completion Notice reports processed/total counts
 - Failed pages are excluded from `syncedPageCount`; the notebook itself is still marked synced (a deterministic render failure would otherwise re-sync forever, especially with automatic sync)
 
+## Panel
+
+- Notebooks are sorted within each folder by the `panelSortOrder` setting (default: recently modified first). Folders keep their own ordering: the top-level group first, then the rest alphabetically
+- An unrecognised `panelSortOrder` falls back to the default rather than breaking the list, so an old or hand-edited value is harmless
+- Name comparison is case-insensitive and numeric-aware, so "Notebook 2" precedes "Notebook 10"
+- Sorting by date breaks ties on name, so the order is total and the list cannot reshuffle between renders
+
 ## Output
 
 - reMarkable folder hierarchy is preserved under the target folder

--- a/documentation/Domain Model.md
+++ b/documentation/Domain Model.md
@@ -86,5 +86,6 @@ Entries whose notebook is no longer present in a fresh cloud listing are orphane
 - `rmfakecloudUrl`: Base URL of the rmfakecloud server
 - `autoSyncEnabled`: Opt-in automatic background sync (default false)
 - `autoSyncIntervalMinutes`: Minutes between automatic syncs (clamped 5–240, default 30)
+- `panelSortOrder`: How the panel orders notebooks (`modified-desc` default, plus `modified-asc`, `name-asc`, `name-desc`)
 - `isAuthenticated`: Derived from token presence
 - `syncStore`: Persistent sync state for all notebooks

--- a/documentation/history/2026-08-01.md
+++ b/documentation/history/2026-08-01.md
@@ -1,0 +1,26 @@
+# 2026-08-01
+
+## Panel sorting (branch `feat/panel-sorting`, off `main`)
+
+The panel listed notebooks in whatever order the cloud returned them, which for 50 daily journals
+is effectively random. Folders were already sorted; notebooks within them were not.
+
+Added `panelSortOrder` (default `modified-desc`) with four orderings, driven by a pure
+`sortNotebooks` in `domain/notebook-sort.ts` with 15 specs. Sorting happens in
+`getFilteredNotebooks`, so the cloud listing is kept as received and changing the order costs only
+a re-render; the grouping downstream preserves it per folder.
+
+Two details worth keeping:
+
+- Name comparison uses `localeCompare` with `numeric: true`. A plain string sort puts
+  "Notebook 10" before "Notebook 2", which reads as broken.
+- Date sorting breaks ties on name. Without a total order, notebooks sharing a timestamp can swap
+  places between renders, which looks like the list flickering.
+
+Branched from `main` rather than stacking on `feat/pdf-export`: unrelated feature, and it keeps
+both reviewable on their own.
+
+**Note for whichever branch merges second:** this branch had to add `panelSortOrder` to the
+hand-written allow-list in `loadSettings`, because the structural fix that makes that impossible to
+forget lives on `feat/pdf-export`. Whoever merges second should drop the hand-written line in
+favour of the iterating version.

--- a/src/app/domain/notebook-sort.spec.ts
+++ b/src/app/domain/notebook-sort.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect, describe } from 'bun:test'
+import { DEFAULT_SORT_VALUE, SORT_MODES, parseSortValue, sortNotebooks } from './notebook-sort'
+import type { NotebookSummary } from './notebook'
+
+const nb = (visibleName: string, lastModified: string, folderPath = ''): NotebookSummary => ({
+    id: `${visibleName}-${lastModified}`,
+    visibleName,
+    parent: '',
+    lastModified,
+    pageCount: 0,
+    folderPath
+})
+
+const names = (list: readonly NotebookSummary[]): string[] => list.map((n) => n.visibleName)
+
+describe('parseSortValue', () => {
+    test('resolves each offered value', () => {
+        for (const mode of SORT_MODES) {
+            expect(parseSortValue(mode.value)).toEqual(mode.mode)
+        }
+    })
+
+    test('an unknown or missing value falls back to the default', () => {
+        expect(parseSortValue(undefined)).toEqual(SORT_MODES[0]!.mode)
+        expect(parseSortValue('nonsense')).toEqual(SORT_MODES[0]!.mode)
+        expect(parseSortValue('')).toEqual(SORT_MODES[0]!.mode)
+    })
+
+    test('the default value is one of the offered modes', () => {
+        expect(SORT_MODES.some((m) => m.value === DEFAULT_SORT_VALUE)).toBe(true)
+    })
+})
+
+describe('sortNotebooks by modified date', () => {
+    const list = [nb('middle', '2000'), nb('newest', '3000'), nb('oldest', '1000')]
+
+    test('newest first', () => {
+        expect(names(sortNotebooks(list, { field: 'modified', direction: 'desc' }))).toEqual([
+            'newest',
+            'middle',
+            'oldest'
+        ])
+    })
+
+    test('oldest first', () => {
+        expect(names(sortNotebooks(list, { field: 'modified', direction: 'asc' }))).toEqual([
+            'oldest',
+            'middle',
+            'newest'
+        ])
+    })
+
+    test('equal timestamps fall back to name, so the order is stable', () => {
+        const tied = [nb('charlie', '500'), nb('alpha', '500'), nb('bravo', '500')]
+        const once = names(sortNotebooks(tied, { field: 'modified', direction: 'desc' }))
+        const twice = names(sortNotebooks(tied, { field: 'modified', direction: 'desc' }))
+
+        expect(once).toEqual(['alpha', 'bravo', 'charlie'])
+        expect(once).toEqual(twice)
+    })
+
+    test('an unparseable timestamp sorts as oldest instead of corrupting the order', () => {
+        const messy = [nb('good', '2000'), nb('broken', 'not-a-number'), nb('older', '1000')]
+        expect(names(sortNotebooks(messy, { field: 'modified', direction: 'desc' }))).toEqual([
+            'good',
+            'older',
+            'broken'
+        ])
+    })
+})
+
+describe('sortNotebooks by name', () => {
+    test('A to Z, case-insensitively', () => {
+        const list = [nb('zebra', '1'), nb('Apple', '1'), nb('mango', '1')]
+        expect(names(sortNotebooks(list, { field: 'name', direction: 'asc' }))).toEqual([
+            'Apple',
+            'mango',
+            'zebra'
+        ])
+    })
+
+    test('Z to A', () => {
+        const list = [nb('Apple', '1'), nb('zebra', '1'), nb('mango', '1')]
+        expect(names(sortNotebooks(list, { field: 'name', direction: 'desc' }))).toEqual([
+            'zebra',
+            'mango',
+            'Apple'
+        ])
+    })
+
+    /**
+     * The real reason for numeric collation: a plain string sort puts
+     * "Notebook 10" before "Notebook 2", which reads as broken.
+     */
+    test('digit runs compare numerically', () => {
+        const list = [nb('Notebook 10', '1'), nb('Notebook 2', '1'), nb('Notebook 1', '1')]
+        expect(names(sortNotebooks(list, { field: 'name', direction: 'asc' }))).toEqual([
+            'Notebook 1',
+            'Notebook 2',
+            'Notebook 10'
+        ])
+    })
+
+    test('dated names sort chronologically by name', () => {
+        const list = [nb('2026-01-24', '9'), nb('2026-07-22', '1'), nb('2026-02-01', '5')]
+        expect(names(sortNotebooks(list, { field: 'name', direction: 'asc' }))).toEqual([
+            '2026-01-24',
+            '2026-02-01',
+            '2026-07-22'
+        ])
+    })
+})
+
+describe('sortNotebooks contract', () => {
+    test('does not mutate the input', () => {
+        const list = [nb('b', '1'), nb('a', '2')]
+        const before = names(list)
+        sortNotebooks(list, { field: 'name', direction: 'asc' })
+        expect(names(list)).toEqual(before)
+    })
+
+    test('keeps every notebook', () => {
+        const list = [nb('a', '1'), nb('b', '2'), nb('c', '3')]
+        for (const mode of SORT_MODES) {
+            expect(sortNotebooks(list, mode.mode)).toHaveLength(3)
+        }
+    })
+
+    test('an empty list stays empty', () => {
+        expect(sortNotebooks([], { field: 'name', direction: 'asc' })).toEqual([])
+    })
+
+    test('a single notebook is returned unchanged', () => {
+        expect(
+            names(sortNotebooks([nb('only', '1')], { field: 'modified', direction: 'desc' }))
+        ).toEqual(['only'])
+    })
+})

--- a/src/app/domain/notebook-sort.ts
+++ b/src/app/domain/notebook-sort.ts
@@ -1,0 +1,86 @@
+import type { NotebookSummary } from './notebook'
+
+export type SortField = 'name' | 'modified'
+export type SortDirection = 'asc' | 'desc'
+
+export interface SortMode {
+    readonly field: SortField
+    readonly direction: SortDirection
+}
+
+/**
+ * The orderings offered in the panel, in the order they appear in the picker.
+ */
+export const SORT_MODES: readonly { value: string; label: string; mode: SortMode }[] = [
+    {
+        value: 'modified-desc',
+        label: 'Recently modified',
+        mode: { field: 'modified', direction: 'desc' }
+    },
+    {
+        value: 'modified-asc',
+        label: 'Oldest modified',
+        mode: { field: 'modified', direction: 'asc' }
+    },
+    { value: 'name-asc', label: 'Name (A–Z)', mode: { field: 'name', direction: 'asc' } },
+    { value: 'name-desc', label: 'Name (Z–A)', mode: { field: 'name', direction: 'desc' } }
+]
+
+export const DEFAULT_SORT_VALUE = 'modified-desc'
+
+/**
+ * Resolve a stored sort value, falling back to the default when it is missing
+ * or no longer recognised.
+ */
+export function parseSortValue(value: string | undefined): SortMode {
+    const found = SORT_MODES.find((m) => m.value === value)
+    return (found ?? SORT_MODES[0]!).mode
+}
+
+/**
+ * `lastModified` arrives as a string of epoch milliseconds. Anything
+ * unparseable sorts as the oldest possible date rather than throwing off the
+ * whole list.
+ */
+function modifiedTime(notebook: NotebookSummary): number {
+    const parsed = parseInt(notebook.lastModified, 10)
+    return Number.isFinite(parsed) ? parsed : 0
+}
+
+/**
+ * Compare names the way a person reads them: case-insensitive, and with digit
+ * runs compared numerically so "Notebook 2" precedes "Notebook 10" instead of
+ * following it.
+ */
+function compareNames(a: NotebookSummary, b: NotebookSummary): number {
+    return a.visibleName.localeCompare(b.visibleName, undefined, {
+        numeric: true,
+        sensitivity: 'base'
+    })
+}
+
+/**
+ * Sort notebooks for display.
+ *
+ * Returns a new array: the panel keeps the unsorted list as it came from the
+ * cloud, and re-sorts on each render.
+ *
+ * Ties fall back to name so the order is total. Without that, two notebooks
+ * modified in the same millisecond could swap places between renders, which
+ * looks like the list flickering.
+ */
+export function sortNotebooks(
+    notebooks: readonly NotebookSummary[],
+    mode: SortMode
+): NotebookSummary[] {
+    const factor = 'asc' === mode.direction ? 1 : -1
+
+    return [...notebooks].sort((a, b) => {
+        if ('name' === mode.field) {
+            return compareNames(a, b) * factor
+        }
+
+        const diff = modifiedTime(a) - modifiedTime(b)
+        return 0 !== diff ? diff * factor : compareNames(a, b)
+    })
+}

--- a/src/app/plugin.ts
+++ b/src/app/plugin.ts
@@ -164,6 +164,9 @@ export class RemarkableSyncPlugin extends Plugin {
             if (loadedSettings.rmfakecloudUrl !== undefined) {
                 draft.rmfakecloudUrl = loadedSettings.rmfakecloudUrl
             }
+            if (loadedSettings.panelSortOrder !== undefined) {
+                draft.panelSortOrder = loadedSettings.panelSortOrder
+            }
             if (loadedSettings.syncStore !== undefined) {
                 draft.syncStore = loadedSettings.syncStore
             }

--- a/src/app/types/plugin-settings.intf.ts
+++ b/src/app/types/plugin-settings.intf.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_SORT_VALUE } from '../domain/notebook-sort'
 import type { SyncStore } from '../domain/sync-state'
 import { DEFAULT_SYNC_STORE } from '../domain/sync-state'
 
@@ -14,6 +15,12 @@ export interface PluginSettings {
     rmfakecloudUrl: string
     autoSyncEnabled: boolean
     autoSyncIntervalMinutes: number
+    /**
+     * How the panel orders notebooks within each folder. One of the values in
+     * `SORT_MODES`; an unrecognised value falls back to the default, so an old
+     * or hand-edited setting cannot break the list.
+     */
+    panelSortOrder: string
     syncStore: SyncStore
 }
 
@@ -26,5 +33,6 @@ export const DEFAULT_SETTINGS: PluginSettings = {
     rmfakecloudUrl: '',
     autoSyncEnabled: false,
     autoSyncIntervalMinutes: DEFAULT_AUTO_SYNC_INTERVAL_MINUTES,
+    panelSortOrder: DEFAULT_SORT_VALUE,
     syncStore: DEFAULT_SYNC_STORE
 }

--- a/src/app/ui/remarkable-panel-view.ts
+++ b/src/app/ui/remarkable-panel-view.ts
@@ -7,6 +7,7 @@ import type {
     PipelineStatus
 } from '../services/pipeline/notebook-pipeline.service'
 import { deriveSyncStatus } from '../domain/sync-state'
+import { SORT_MODES, parseSortValue, sortNotebooks } from '../domain/notebook-sort'
 import type { SyncStatus } from '../domain/sync-state'
 import { formatRemarkableDate } from '../../utils/date-utils'
 import { fuzzyMatch } from '../../utils/fuzzy-match'
@@ -218,6 +219,28 @@ export class RemarkablePanelView extends ItemView {
                 this.render()
             })
         }
+
+        // Sort order. A single select rather than a field button plus a
+        // direction toggle: the panel is narrow, and four named orderings are
+        // easier to scan than two controls that have to be combined mentally.
+        const sortRow = toolbar.createDiv({ cls: 'remarkable-sort-row' })
+        sortRow.createSpan({ cls: 'remarkable-sort-label', text: 'Sort' })
+        const sortSelect = sortRow.createEl('select', {
+            cls: 'remarkable-sort-select',
+            attr: { 'aria-label': 'Sort notebooks' }
+        })
+        for (const option of SORT_MODES) {
+            sortSelect.createEl('option', { value: option.value, text: option.label })
+        }
+        sortSelect.value = this.plugin.settings.panelSortOrder
+        sortSelect.addEventListener('change', () => {
+            void (async (): Promise<void> => {
+                await this.plugin.updateSettings((draft) => {
+                    draft.panelSortOrder = sortSelect.value
+                })
+                this.render()
+            })()
+        })
     }
 
     private getFilteredNotebooks(): NotebookSummary[] {
@@ -243,7 +266,10 @@ export class RemarkablePanelView extends ItemView {
                 break
         }
 
-        return filtered
+        // Sorted here rather than at load time so the cloud listing stays as
+        // received, and changing the order costs only a re-render. Grouping
+        // downstream preserves this order within each folder.
+        return sortNotebooks(filtered, parseSortValue(this.plugin.settings.panelSortOrder))
     }
 
     private renderNotebookList(container: HTMLElement): void {

--- a/src/styles.src.css
+++ b/src/styles.src.css
@@ -203,6 +203,30 @@
     color: var(--text-faint);
 }
 
+/* Sort order picker, sitting under the filter buttons */
+.remarkable-sort-row {
+    @apply flex items-center gap-2 mt-2;
+}
+
+.remarkable-sort-label {
+    @apply text-xs font-medium;
+    color: var(--text-muted);
+}
+
+.remarkable-sort-select {
+    @apply flex-1 text-xs py-1 px-2 cursor-pointer;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s);
+    background-color: var(--background-primary);
+    color: var(--text-normal);
+    /* The panel can be narrow; never let the select force a horizontal scroll */
+    min-width: 0;
+}
+
+.remarkable-sort-select:hover {
+    background-color: var(--background-modifier-hover);
+}
+
 .remarkable-filter-row {
     @apply flex items-center gap-0;
     border: 1px solid var(--background-modifier-border);


### PR DESCRIPTION
## What

The panel listed notebooks in whatever order the cloud returned them. With 50 daily journals that is effectively random. Folders were already sorted; notebooks inside them were not.

Adds a **Sort** picker: recently modified (default), oldest modified, name A–Z, name Z–A. Persisted as `panelSortOrder`.

## Design notes

- Ordering lives in a pure `sortNotebooks` (`domain/notebook-sort.ts`) with 15 specs, so it is testable without the UI.
- Sorting runs in `getFilteredNotebooks`, so the cloud listing is kept as received and changing order costs only a re-render.
- Folder ordering is unchanged: top-level group first, rest alphabetical.

## Two decisions worth checking

- **Numeric name collation.** `localeCompare(..., { numeric: true })`, so "Notebook 2" precedes "Notebook 10". Without it a plain string sort reverses them.
- **Date sorting breaks ties on name.** Without a total order, notebooks sharing a timestamp can swap between renders, which looks like flickering.

## Where to attack this

- **Default is "recently modified".** Debatable for date-named notebooks, where name ascending may read better. One-line change.
- **A `<select>`, not a header-click sort.** The panel is narrow and there is no table header to click. If you would rather have a field button plus a direction toggle, that is two controls in a sidebar that is already cramped.
- **Folder ordering is untouched.** Sorting folders by date has no obvious meaning since folders carry no timestamp, so they stay alphabetical. Arguable.
- **The picker has never rendered in Obsidian.** The sort logic is unit tested; the `<select>` and its CSS are not.

## Risk

Low. One new pure module, one new setting, one toolbar control. No change to sync, parsing or output.
